### PR TITLE
fixed credential parsing

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -47,6 +47,25 @@ from impacket.smb3structs import *
 from impacket import ntlm
 from impacket.ntlm import AV_PAIRS, NTLMSSP_AV_TIME, NTLMSSP_AV_FLAGS, NTOWFv2, NTLMSSP_AV_TARGET_NAME, NTLMSSP_AV_HOSTNAME,USE_NTLMv2, hmac_md5
 
+def parse_creds(target):
+    creds, remote_name = target.rsplit('@', 1)
+    if ':' in creds:
+        colon_split = creds.split(':', 1) # dom/user, pass
+        password = colon_split[1]
+        creds = colon_split[0]
+    else:
+        password = ''
+
+    if '/' in creds:
+        slash_split = creds.split("/", 1)
+        dom = slash_split[0].strip()
+        user = slash_split[1].strip()
+    else:
+        dom = ''
+        user = creds
+
+    return dom, user, password, remote_name
+
 # Slightly modified version of impackets computeResponseNTLMv2
 def mod_computeResponseNTLMv2(flags, serverChallenge, clientChallenge, serverName, domain, user, password, lmhash='',
                               nthash='', use_ntlmv2=USE_NTLMv2, check=False):
@@ -170,18 +189,7 @@ def main():
 
     options = parser.parse_args()
 
-    import re
-
-    domain, username, password, remote_name = re.compile('(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)').match(
-        options.target).groups('')
-
-    #In case the password contains '@'
-    if '@' in remote_name:
-        password = password + '@' + remote_name.rpartition('@')[0]
-        remote_name = remote_name.rpartition('@')[2]
-
-    if domain is None:
-        domain = ''
+    domain, username, password, remote_name = parse_creds(options.target)
 
     if password == '' and username == '':
         logging.error("Please supply a username/password (you can't use this scanner with anonymous authentication)")


### PR DESCRIPTION
@ signs in passwords don't work in the current regex parsing. This is a more reliable, easier to read way of parsing the target option.

parse_creds('a/d@1.1.1.1')
('a', 'd', '', '1.1.1.1')
parse_creds('a/d::::@@@@///@@@@1.1.1.1')
('a', 'd', ':::@@@@///@@@', '1.1.1.1')
parse_creds('d::::@@@@///@@@@1.1.1.1')
('', 'd', ':::@@@@///@@@', '1.1.1.1')
parse_creds('d@1.1.1.1')
('', 'd', '', '1.1.1.1')